### PR TITLE
Add docker instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Le plus dur est de [faire marcher le serveur jekyll](http://jekyllrb.com/docs/in
 
 Ces instructions sont valables pour des systèmes Unix (Mac OS ou Linux). Il existe aussi une [documentation pour windows](http://jekyllrb.com/docs/windows/#installation) que je n'ai pas essayée.
 
+### Alternative avec docker
+
+Si docker est installé sur votre poste.
+
+1. Placez-vous à la racine du projet.
+2. Lancez `docker run --rm -v "$PWD:/src" -p 4000:4000 grahamc/jekyll serve --watch`
+3. Ouvrez votre navigateur préféré avec l'url `localhost:4000/pajomatic/`
+
+Normalement, les modifications faites dans le code sont disponibles aprés un simple rafraîchissement dans le navigateur.
+
 ## Comment contribuer ?
 
 ### Pull Requests


### PR DESCRIPTION
On aime bien utiliser docker chez nous lorsqu'une image existe déjà. Ca évite de trop se prendre la tete avec les dépendances, les numeros de version etc.