### PR TITLE
Indemnités d'entretien et nombre de jours affichés sur 2 lignes au lieu de 4

### DIFF
--- a/annee-complete.html
+++ b/annee-complete.html
@@ -29,10 +29,10 @@ controller: annee-complete
             <div class="col-md-6">
               {% include form/input-group.html id="nb_heures_majorees" addon="heures majorées" required=false %}
             </div>
-        </div>
+          </div>
 
         </div>
-          <div class="form-group">
+        <div class="form-group">
           <label for="salaire_net_normal">
             Salaire horaire net d'une heure normale
           </label>
@@ -40,30 +40,39 @@ controller: annee-complete
         </div>
 
         <div class="form-group">
-        <label for="majoration_heures_majorees">
-          Majoration des heures majorées
-        </label>
+          <label for="majoration_heures_majorees">
+            Majoration des heures majorées
+          </label>
           {% include form/input-group.html id="majoration_heures_majorees" addon="%" required=true %}
-      </div>
-
-        <div class="form-group">
-        <label for="indemnite_entretien">Indemnité d'entretien, tranche 1</label>
-          {% include form/input-group.html id="indemnite_entretien" addon="€ par jour" required=true %}
         </div>
 
-        <div class="form-group">
-        <label for="indemnite_entretien_2">Indemnité d'entretien, tranche 2</label>
-          {% include form/input-group.html id="indemnite_entretien_2" addon="€ par jour" required=true %}
+        <div class="row">
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="indemnite_entretien">Indemnité d'entretien, tranche 1</label>
+              {% include form/input-group.html id="indemnite_entretien" addon="€ par jour" required=true %}
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="indemnite_entretien_2">Indemnité d'entretien, tranche 2</label>
+              {% include form/input-group.html id="indemnite_entretien_2" addon="€ par jour" required=true %}
+            </div>
+          </div>
         </div>
-
-        <div class="form-group">
-        <label for="indemnite_entretien_3">Indemnité d'entretien, tranche 3</label>
-          {% include form/input-group.html id="indemnite_entretien_3" addon="€ par jour" required=true %}
-        </div>
-
-        <div class="form-group">
-        <label for="indemnite_entretien_4">Indemnité d'entretien, tranche 4</label>
-          {% include form/input-group.html id="indemnite_entretien_4" addon="€ par jour" required=true %}
+        <div class="row">
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="indemnite_entretien_3">Indemnité d'entretien, tranche 3</label>
+              {% include form/input-group.html id="indemnite_entretien_3" addon="€ par jour" required=true %}
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="indemnite_entretien_4">Indemnité d'entretien, tranche 4</label>
+              {% include form/input-group.html id="indemnite_entretien_4" addon="€ par jour" required=true %}
+            </div>
+          </div>
         </div>
 
         <div class="form-group">
@@ -83,24 +92,33 @@ controller: annee-complete
       <fieldset>
         <legend>Mois en cours</legend>
 
-        <div class="form-group">
-          <label for="nb_jours_accueil_reel">Nombre de jours d'accueil réels dans le mois, tranche 1 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 1. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
-          {% include form/input-group.html id="nb_jours_accueil_reel" addon="jours" required=true %}
+        <div class="row">
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="nb_jours_accueil_reel">Nombre de jours d'accueil réels dans le mois, tranche 1 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 1. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
+              {% include form/input-group.html id="nb_jours_accueil_reel" addon="jours" required=true %}
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="nb_jours_accueil_reel_2">Nombre de jours d'accueil réels dans le mois, tranche 2 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 2. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
+              {% include form/input-group.html id="nb_jours_accueil_reel_2" addon="jours" required=true %}
+            </div>
+          </div>
         </div>
-
-        <div class="form-group">
-          <label for="nb_jours_accueil_reel_2">Nombre de jours d'accueil réels dans le mois, tranche 2 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 2. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
-          {% include form/input-group.html id="nb_jours_accueil_reel_2" addon="jours" required=true %}
-        </div>
-
-        <div class="form-group">
-          <label for="nb_jours_accueil_reel_3">Nombre de jours d'accueil réels dans le mois, tranche 3 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 3. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
-          {% include form/input-group.html id="nb_jours_accueil_reel_3" addon="jours" required=true %}
-        </div>
-
-        <div class="form-group">
-          <label for="nb_jours_accueil_reel_4">Nombre de jours d'accueil réels dans le mois, tranche 4 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 4. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
-          {% include form/input-group.html id="nb_jours_accueil_reel_4" addon="jours" required=true %}
+        <div class="row">
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="nb_jours_accueil_reel_3">Nombre de jours d'accueil réels dans le mois, tranche 3 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 3. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
+              {% include form/input-group.html id="nb_jours_accueil_reel_3" addon="jours" required=true %}
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="nb_jours_accueil_reel_4">Nombre de jours d'accueil réels dans le mois, tranche 4 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 4. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
+              {% include form/input-group.html id="nb_jours_accueil_reel_4" addon="jours" required=true %}
+            </div>
+          </div>
         </div>
 
         <div class="form-group">

--- a/index.html
+++ b/index.html
@@ -100,24 +100,33 @@ controller: annee-incomplete
       <fieldset>
         <legend>Mois en cours</legend>
 
-        <div class="form-group">
-          <label for="nb_jours_accueil_reel">Nombre de jours d'accueil réels dans le mois, tranche 1 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 1. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
-          {% include form/input-group.html id="nb_jours_accueil_reel" addon="jours" required=true %}
+        <div class="row">
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="nb_jours_accueil_reel">Nombre de jours d'accueil réels dans le mois, tranche 1 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 1. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
+              {% include form/input-group.html id="nb_jours_accueil_reel" addon="jours" required=true %}
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="nb_jours_accueil_reel_2">Nombre de jours d'accueil réels dans le mois, tranche 2 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 2. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
+              {% include form/input-group.html id="nb_jours_accueil_reel_2" addon="jours" required=true %}
+            </div>
+          </div>
         </div>
-
-        <div class="form-group">
-          <label for="nb_jours_accueil_reel_2">Nombre de jours d'accueil réels dans le mois, tranche 2 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 2. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
-          {% include form/input-group.html id="nb_jours_accueil_reel_2" addon="jours" required=true %}
-        </div>
-
-        <div class="form-group">
-          <label for="nb_jours_accueil_reel_3">Nombre de jours d'accueil réels dans le mois, tranche 3 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 3. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
-          {% include form/input-group.html id="nb_jours_accueil_reel_3" addon="jours" required=true %}
-        </div>
-
-        <div class="form-group">
-          <label for="nb_jours_accueil_reel_4">Nombre de jours d'accueil réels dans le mois, tranche 4 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 4. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
-          {% include form/input-group.html id="nb_jours_accueil_reel_4" addon="jours" required=true %}
+        <div class="row">
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="nb_jours_accueil_reel_3">Nombre de jours d'accueil réels dans le mois, tranche 3 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 3. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
+              {% include form/input-group.html id="nb_jours_accueil_reel_3" addon="jours" required=true %}
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="nb_jours_accueil_reel_4">Nombre de jours d'accueil réels dans le mois, tranche 4 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 4. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>
+              {% include form/input-group.html id="nb_jours_accueil_reel_4" addon="jours" required=true %}
+            </div>
+          </div>
         </div>
 
         <div class="form-group">

--- a/index.html
+++ b/index.html
@@ -54,24 +54,33 @@ controller: annee-incomplete
           {% include form/input-group.html id="majoration_heures_majorees" addon="%" required=true %}
         </div>
 
-        <div class="form-group">
-          <label for="indemnite_entretien">Indemnité d'entretien, tranche 1</label>
-          {% include form/input-group.html id="indemnite_entretien" addon="€ par jour" required=true %}
+        <div class="row">
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="indemnite_entretien">Indemnité d'entretien, tranche 1</label>
+              {% include form/input-group.html id="indemnite_entretien" addon="€ par jour" required=true %}
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="indemnite_entretien_2">Indemnité d'entretien, tranche 2</label>
+              {% include form/input-group.html id="indemnite_entretien_2" addon="€ par jour" required=true %}
+            </div>
+          </div>
         </div>
-
-        <div class="form-group">
-          <label for="indemnite_entretien_2">Indemnité d'entretien, tranche 2</label>
-          {% include form/input-group.html id="indemnite_entretien_2" addon="€ par jour" required=true %}
-        </div>
-
-        <div class="form-group">
-          <label for="indemnite_entretien_3">Indemnité d'entretien, tranche 3</label>
-          {% include form/input-group.html id="indemnite_entretien_3" addon="€ par jour" required=true %}
-        </div>
-
-        <div class="form-group">
-          <label for="indemnite_entretien_4">Indemnité d'entretien, tranche 4</label>
-          {% include form/input-group.html id="indemnite_entretien_4" addon="€ par jour" required=true %}
+        <div class="row">
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="indemnite_entretien_3">Indemnité d'entretien, tranche 3</label>
+              {% include form/input-group.html id="indemnite_entretien_3" addon="€ par jour" required=true %}
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="form-group">
+              <label for="indemnite_entretien_4">Indemnité d'entretien, tranche 4</label>
+              {% include form/input-group.html id="indemnite_entretien_4" addon="€ par jour" required=true %}
+            </div>
+          </div>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
Avant : 
![plop d 2015-12-14 a 21 32 20](https://cloud.githubusercontent.com/assets/1035145/11793155/4f066dd6-a2aa-11e5-8ec2-6397cd33a54d.png)

Après : 
![plop d 2015-12-14 a 21 32 04](https://cloud.githubusercontent.com/assets/1035145/11793150/47b77336-a2aa-11e5-8402-cf1cf7b3721b.png)

Ça ne change rien sur les plus petits écrans.