### PR TITLE
Ajout d'un champ "notes"

### DIFF
--- a/_includes/content/base-mois-en-cours.html
+++ b/_includes/content/base-mois-en-cours.html
@@ -2,7 +2,7 @@
   <div class="col-md-12">
     <div class="form-group">
       <label for="notes_mois_courant">Notes</label>
-      <div><textarea name="notes_mois_courant" id="notes_mois_courant" cols="30" rows="2" class="form-control"></textarea></div>
+      <div><textarea name="notes_mois_courant" id="notes_mois_courant" cols="30" rows="2" class="form-control not-numeric"></textarea></div>
     </div>
   </div>
 </div>

--- a/_includes/content/base-mois-en-cours.html
+++ b/_includes/content/base-mois-en-cours.html
@@ -1,4 +1,12 @@
 <div class="row">
+  <div class="col-md-12">
+    <div class="form-group">
+      <label for="notes_mois_courant">Notes</label>
+      <div><textarea name="notes_mois_courant" id="notes_mois_courant" cols="30" rows="2" class="form-control"></textarea></div>
+    </div>
+  </div>
+</div>
+<div class="row">
   <div class="col-md-6">
     <div class="form-group">
       <label for="nb_jours_accueil_reel">Nombre de jours d'accueil réels dans le mois, tranche 1 {% include form/help.html content="Le nombre de jours où votre enfant a été gardé par l'assistante maternelle pour ce mois-ci, au tarif de la tranche 1. Il sert à calculer le montant des indemnités, ces dernières n'étant pas mensualisables." %}</label>

--- a/_includes/content/input-reminder.html
+++ b/_includes/content/input-reminder.html
@@ -22,6 +22,7 @@
     </td>
     <td>
       <ul>
+        <li><strong>Notes&nbsp;:</strong><p id="in_notes_mois_courant"></p></li>
         <li><strong id="in_nb_jours_accueil_reel"></strong> jours d'accueil réels</li>
         <li>Nombre de repas :
           <ul>

--- a/css/adjust.scss
+++ b/css/adjust.scss
@@ -41,3 +41,7 @@ footer {
   border: 3px solid darken($pajePurple, 15%);
   font-size: 1.6em;
 }
+
+textarea {
+  resize: vertical;
+}

--- a/js/view.js
+++ b/js/view.js
@@ -13,11 +13,12 @@ var pajomatic_view = function () {
         $.each(form.serializeArray(), function (i, element) {
             var name = element.name;
             var value = element.value;
-            if (is_numeric.test(value)) {
+            if ($('[name='+name+']').hasClass('not-numeric')) {
+                clean_value = value;
+            } else if (is_numeric.test(value)) {
                 clean_value = parseFloat(is_numeric.exec(value)[0].replace(',','.'));
             } else {
                 clean_value = 0;
-                //$('[name='+name+']').val(clean_value);
             }
             finalData[name] = clean_value;
 


### PR DESCRIPTION
Voici une fonctionnalité qui va bien me servir avec mes fréquents retards et arrangements d'horaires, j'aurais dû l'ajouter il y a longtemps. ^^

Ajout du champ au début de la partie "mois en cours" : 
![plop d 2015-12-30 a 10 52 50](https://cloud.githubusercontent.com/assets/1035145/12049116/8040f264-aee3-11e5-9df1-6b637ea9956e.png)

La valeur est bien transmise, retours à la ligne compris, dans le lien partageable. (Ce qui était l'objectif initial quand même.)
La zone de texte est redimensionnable en hauteur.
J'ai dû modifier légèrement le JS pour pouvoir afficher le rappel des notes dans le récapitulatif imprimé.